### PR TITLE
chore(deps): bump wizcli from 1.21.0 to 1.59.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for azure-blob-cli
-wiz_ver: 1.21.0
+wiz_ver: 1.59.0
 wiz_parent_install_dir: /usr/local
 wiz_os: linux
 


### PR DESCRIPTION
## Summary
- Bump `wiz_ver` to 1.59.0 (latest available release under https://downloads.wiz.io/v1/wizcli/)

## Test plan
- [ ] CI (container-branches) passes